### PR TITLE
Parse string constant escape sequences

### DIFF
--- a/lua/entities/gmod_wire_fpga/init.lua
+++ b/lua/entities/gmod_wire_fpga/init.lua
@@ -805,7 +805,11 @@ function ENT:Run(changedNodes)
     if gate.isInput then
       value = {self.InputValues[nodeId]}
     elseif gate.isConstant then
-      value = {node.value}
+      if gate.outputtypes[1] == "STRING" then
+        value = { WireLib.ParseEscapes(node.value) }
+      else
+        value = {node.value}
+      end
     else
       if nodeId == loopDetectionNodeId and #nodeQueue == loopDetectionSize then
         --infinite loop...


### PR DESCRIPTION
Utilizes `WireLib.ParseEscapes` to remove escape sequences from string constants.

Fixes #27

[Example code](https://gist.github.com/Denneisk/74e540a21230f89d3124c3b1f2b2e99a)
